### PR TITLE
Add some customization options  

### DIFF
--- a/plugin/CpuTempApplet.vala
+++ b/plugin/CpuTempApplet.vala
@@ -15,7 +15,7 @@ public class CpuTempSettings : Gtk.Grid {
 	private unowned Gtk.Entry? sensor_entry;
 
 	[GtkChild]
-	private unowned Gtk.Switch? fscale_switch;
+	private unowned Gtk.Switch? fahrenheit_switch;
 
 	[GtkChild]
 	private unowned Gtk.Switch? show_sign_switch;
@@ -25,9 +25,9 @@ public class CpuTempSettings : Gtk.Grid {
 
 		populate_combobox();
 
-		settings.bind("sensor",    sensor_entry,     "text",  SettingsBindFlags.DEFAULT);
-		settings.bind("fscale",    fscale_switch,    "state", SettingsBindFlags.DEFAULT);
-		settings.bind("show-sign", show_sign_switch, "state", SettingsBindFlags.DEFAULT);
+		settings.bind("sensor",     sensor_entry,      "text",  SettingsBindFlags.DEFAULT);
+		settings.bind("fahrenheit", fahrenheit_switch, "state", SettingsBindFlags.DEFAULT);
+		settings.bind("show-sign",  show_sign_switch,  "state", SettingsBindFlags.DEFAULT);
 	}
 
 	protected void populate_combobox() {
@@ -151,15 +151,15 @@ public class CpuTempApplet : Budgie.Applet {
 
 	protected string format_temp() {
 		var temp = this.temp;
-		var fscale = settings.get_boolean("fscale");
-		if (fscale) {
+		var fahrenheit = settings.get_boolean("fahrenheit");
+		if (fahrenheit) {
 			temp = temp * 1.8 + 32;
 		}
 
 		var show_sign = settings.get_boolean("show-sign");
 		var sign = "";
 		if (show_sign) {
-			sign = fscale ? "F" : "C";
+			sign = fahrenheit ? "F" : "C";
 		}
 
 		return "%.1f°%s".printf(temp, sign);

--- a/plugin/CpuTempApplet.vala
+++ b/plugin/CpuTempApplet.vala
@@ -12,14 +12,18 @@ public class CpuTempSettings : Gtk.Grid {
 	private unowned Gtk.ComboBoxText? combobox;
 
 	[GtkChild]
-	private unowned Gtk.Entry? entry;
+	private unowned Gtk.Entry? sensor_entry;
+
+	[GtkChild]
+	private unowned Gtk.Switch? fscale_switch;
 
 	public CpuTempSettings(Settings? settings) {
 		this.settings = settings;
 
 		populate_combobox();
 
-		settings.bind("sensor", entry, "text", SettingsBindFlags.DEFAULT);
+		settings.bind("sensor", sensor_entry,  "text",  SettingsBindFlags.DEFAULT);
+		settings.bind("fscale", fscale_switch, "state", SettingsBindFlags.DEFAULT);
 	}
 
 	protected void populate_combobox() {
@@ -106,6 +110,8 @@ public class CpuTempApplet : Budgie.Applet {
 				this.sensor = sensor;
 			}
 		}
+
+		update_temp();
 	}
 
 	protected void get_sensors() {
@@ -126,7 +132,7 @@ public class CpuTempApplet : Budgie.Applet {
 		fetch_temp();
 
 		var old_format = temp_label.get_label();
-		var format = "%.1f°".printf (temp);
+		var format = format_temp();
 
 		if (old_format == format) {
 			return true;
@@ -137,6 +143,16 @@ public class CpuTempApplet : Budgie.Applet {
 		queue_draw();
 
 		return true;
+	}
+
+	protected string format_temp() {
+		var temp = this.temp;
+		var fscale = settings.get_boolean("fscale");
+		if (fscale) {
+			temp = temp * 1.8 + 32;
+		}
+
+		return "%.1f°".printf(temp);
 	}
 }
 

--- a/plugin/CpuTempApplet.vala
+++ b/plugin/CpuTempApplet.vala
@@ -20,14 +20,18 @@ public class CpuTempSettings : Gtk.Grid {
 	[GtkChild]
 	private unowned Gtk.Switch? show_sign_switch;
 
+	[GtkChild]
+	private unowned Gtk.Switch? show_fraction_switch;
+
 	public CpuTempSettings(Settings? settings) {
 		this.settings = settings;
 
 		populate_combobox();
 
-		settings.bind("sensor",     sensor_entry,      "text",  SettingsBindFlags.DEFAULT);
-		settings.bind("fahrenheit", fahrenheit_switch, "state", SettingsBindFlags.DEFAULT);
-		settings.bind("show-sign",  show_sign_switch,  "state", SettingsBindFlags.DEFAULT);
+		settings.bind("sensor",        sensor_entry,         "text",  SettingsBindFlags.DEFAULT);
+		settings.bind("fahrenheit",    fahrenheit_switch,    "state", SettingsBindFlags.DEFAULT);
+		settings.bind("show-sign",     show_sign_switch,     "state", SettingsBindFlags.DEFAULT);
+		settings.bind("show-fraction", show_fraction_switch, "state", SettingsBindFlags.DEFAULT);
 	}
 
 	protected void populate_combobox() {
@@ -162,7 +166,13 @@ public class CpuTempApplet : Budgie.Applet {
 			sign = fahrenheit ? "F" : "C";
 		}
 
-		return "%.1f°%s".printf(temp, sign);
+		var show_fraction = settings.get_boolean("show-fraction");
+		if (show_fraction) {
+			return "%.1f°%s".printf(temp, sign);
+		}
+		else {
+			return "%.0f°%s".printf(temp, sign);
+		}
 	}
 }
 

--- a/plugin/CpuTempApplet.vala
+++ b/plugin/CpuTempApplet.vala
@@ -17,13 +17,17 @@ public class CpuTempSettings : Gtk.Grid {
 	[GtkChild]
 	private unowned Gtk.Switch? fscale_switch;
 
+	[GtkChild]
+	private unowned Gtk.Switch? show_sign_switch;
+
 	public CpuTempSettings(Settings? settings) {
 		this.settings = settings;
 
 		populate_combobox();
 
-		settings.bind("sensor", sensor_entry,  "text",  SettingsBindFlags.DEFAULT);
-		settings.bind("fscale", fscale_switch, "state", SettingsBindFlags.DEFAULT);
+		settings.bind("sensor",    sensor_entry,     "text",  SettingsBindFlags.DEFAULT);
+		settings.bind("fscale",    fscale_switch,    "state", SettingsBindFlags.DEFAULT);
+		settings.bind("show-sign", show_sign_switch, "state", SettingsBindFlags.DEFAULT);
 	}
 
 	protected void populate_combobox() {
@@ -152,7 +156,13 @@ public class CpuTempApplet : Budgie.Applet {
 			temp = temp * 1.8 + 32;
 		}
 
-		return "%.1f°".printf(temp);
+		var show_sign = settings.get_boolean("show-sign");
+		var sign = "";
+		if (show_sign) {
+			sign = fscale ? "F" : "C";
+		}
+
+		return "%.1f°%s".printf(temp, sign);
 	}
 }
 

--- a/plugin/com.github.tarkah.budgie-cputemp-applet.gschema.xml
+++ b/plugin/com.github.tarkah.budgie-cputemp-applet.gschema.xml
@@ -16,5 +16,10 @@
         <description>If true, C/F sign is displayed. Otherwise, not.</description>
         <default>false</default>
     </key>
+    <key type="b" name="show-fraction">
+        <summary>Show fraction part of temperature.</summary>
+        <description>If true, the fraction part of the temperature is displayed. Otherwise, not.</description>
+        <default>true</default>
+    </key>
   </schema>
 </schemalist>

--- a/plugin/com.github.tarkah.budgie-cputemp-applet.gschema.xml
+++ b/plugin/com.github.tarkah.budgie-cputemp-applet.gschema.xml
@@ -6,5 +6,10 @@
         <description>Sensor to display temperature for</description>
         <default>""</default>
     </key>
+    <key type="b" name="fscale">
+        <summary>Show temperature in Fahrenheit scale instead of Celsius</summary>
+        <description>If true, tempereture is displayed in Fahrenheit scale. Otherwise, Celsius.</description>
+        <default>false</default>
+    </key>
   </schema>
 </schemalist>

--- a/plugin/com.github.tarkah.budgie-cputemp-applet.gschema.xml
+++ b/plugin/com.github.tarkah.budgie-cputemp-applet.gschema.xml
@@ -6,7 +6,7 @@
         <description>Sensor to display temperature for</description>
         <default>""</default>
     </key>
-    <key type="b" name="fscale">
+    <key type="b" name="fahrenheit">
         <summary>Show temperature in Fahrenheit scale instead of Celsius</summary>
         <description>If true, tempereture is displayed in Fahrenheit scale. Otherwise, Celsius.</description>
         <default>false</default>

--- a/plugin/com.github.tarkah.budgie-cputemp-applet.gschema.xml
+++ b/plugin/com.github.tarkah.budgie-cputemp-applet.gschema.xml
@@ -11,5 +11,10 @@
         <description>If true, tempereture is displayed in Fahrenheit scale. Otherwise, Celsius.</description>
         <default>false</default>
     </key>
+    <key type="b" name="show-sign">
+        <summary>Show C/F after degree sign.</summary>
+        <description>If true, C/F sign is displayed. Otherwise, not.</description>
+        <default>false</default>
+    </key>
   </schema>
 </schemalist>

--- a/plugin/settings.ui
+++ b/plugin/settings.ui
@@ -58,7 +58,7 @@
       </packing>
     </child>
     <child>
-      <object class="GtkSwitch" id="fscale_switch">
+      <object class="GtkSwitch" id="fahrenheit_switch">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
         <property name="halign">start</property>

--- a/plugin/settings.ui
+++ b/plugin/settings.ui
@@ -105,5 +105,37 @@
         <property name="top-attach">2</property>
       </packing>
     </child>
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="halign">start</property>
+        <property name="valign">center</property>
+        <property name="margin-top">20</property>
+        <property name="margin-end">10</property>
+        <property name="hexpand">True</property>
+        <property name="label" translatable="yes">Show Fraction</property>
+      </object>
+      <packing>
+        <property name="left-attach">0</property>
+        <property name="top-attach">3</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkSwitch" id="show_fraction_switch">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="halign">start</property>
+        <property name="valign">center</property>
+        <property name="margin-top">20</property>
+        <property name="margin-start">10</property>
+        <property name="active">True</property>
+        <property name="state">True</property>
+      </object>
+      <packing>
+        <property name="left-attach">1</property>
+        <property name="top-attach">3</property>
+      </packing>
+    </child>
   </template>
 </interface>

--- a/plugin/settings.ui
+++ b/plugin/settings.ui
@@ -73,5 +73,37 @@
         <property name="top-attach">1</property>
       </packing>
     </child>
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="halign">start</property>
+        <property name="valign">center</property>
+        <property name="margin-top">20</property>
+        <property name="margin-end">10</property>
+        <property name="hexpand">True</property>
+        <property name="label" translatable="yes">Show C/F Sign</property>
+      </object>
+      <packing>
+        <property name="left-attach">0</property>
+        <property name="top-attach">2</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkSwitch" id="show_sign_switch">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="halign">start</property>
+        <property name="valign">center</property>
+        <property name="margin-top">20</property>
+        <property name="margin-start">10</property>
+        <property name="active">True</property>
+        <property name="state">False</property>
+      </object>
+      <packing>
+        <property name="left-attach">1</property>
+        <property name="top-attach">2</property>
+      </packing>
+    </child>
   </template>
 </interface>

--- a/plugin/settings.ui
+++ b/plugin/settings.ui
@@ -30,7 +30,7 @@
         <property name="hexpand">True</property>
         <property name="has-entry">True</property>
         <child internal-child="entry">
-          <object class="GtkEntry" id="entry">
+          <object class="GtkEntry" id="sensor_entry">
             <property name="can-focus">False</property>
             <property name="placeholder-text" translatable="yes">Choose...</property>
           </object>
@@ -39,6 +39,38 @@
       <packing>
         <property name="left-attach">1</property>
         <property name="top-attach">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="halign">start</property>
+        <property name="valign">center</property>
+        <property name="margin-top">20</property>
+        <property name="margin-end">10</property>
+        <property name="hexpand">True</property>
+        <property name="label" translatable="yes">Fahrenheit Scale</property>
+      </object>
+      <packing>
+        <property name="left-attach">0</property>
+        <property name="top-attach">1</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkSwitch" id="fscale_switch">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="halign">start</property>
+        <property name="valign">center</property>
+        <property name="margin-top">20</property>
+        <property name="margin-start">10</property>
+        <property name="active">True</property>
+        <property name="state">False</property>
+      </object>
+      <packing>
+        <property name="left-attach">1</property>
+        <property name="top-attach">1</property>
       </packing>
     </child>
   </template>


### PR DESCRIPTION
Hi @tarkah
First of all, thanks for creating this nice applet. This is exactly what I was looking for. I love it.
Anyway, this PR aims to add 2 options below to the applet to make it a bit more customizable.

1. Switch between Celsius and Fahrenheit scales.
2. Show or hide C/F sign.

![cputemp3](https://user-images.githubusercontent.com/30318985/121766145-e900c800-cb8a-11eb-9860-6160c4bdcc6d.png)
![cputemp1](https://user-images.githubusercontent.com/30318985/121766183-35e49e80-cb8b-11eb-9804-26630e1c3150.png)
![cputemp2](https://user-images.githubusercontent.com/30318985/121766142-e7370480-cb8a-11eb-8a0e-d1ec19619cb2.png)
