### PR TITLE
Add support for Raspberry Pi 4B.

### DIFF
--- a/plugin/Sensors.vala
+++ b/plugin/Sensors.vala
@@ -12,7 +12,12 @@ namespace Sensors {
         }
 
         public string display_name() {
-            return this.name + " - " + this.label;
+            if (this.label != "") {
+                return this.name + " - " + this.label;
+            }
+            else {
+                return this.name;
+            }
         }
     }
 
@@ -76,15 +81,17 @@ namespace Sensors {
 
             if (sensor_name != "") {
                 while ((name = dir.read_name ()) != null) {
-                    if (name.substring(0,4)=="temp" && name.substring(-5,5)=="label") {
-                        string label_path = Path.build_filename(directory, name);
-                        string input_path = Path.build_filename(directory, name.replace("label", "input") );
-            
+                    if (name.has_prefix("temp") && name.has_suffix("input")) {
+                        string label_path = Path.build_filename(directory, name.replace("input", "label") );
+                        string input_path = Path.build_filename(directory, name);
+
+                        string label = "";
+                        if (FileUtils.test (label_path, FileTest.IS_REGULAR)) {
+                            label = get_file_contents(label_path);
+                        }
+
                         if (FileUtils.test (input_path, FileTest.IS_REGULAR)) {
-                            string label = get_file_contents(label_path);
-
                             Sensor sensor = new Sensor(sensor_name, label, input_path);
-
                             sensors += sensor;
                         }
                     }


### PR DESCRIPTION
This PR enables the applet to work on Raspberry Pi 4B.
Pi is a bit different in the structure of ```/sys/class/hwmon/``` directory, so I have modified the program to read it.
Of course, this works on x86/amd64 systems as before. 

![temp-raspi4](https://user-images.githubusercontent.com/30318985/122577686-08698a80-d08e-11eb-9379-a5b81f6f5664.png)